### PR TITLE
Addfront fix

### DIFF
--- a/web/backend/communect/src/main/kotlin/com/example/communect/app/service/UserServiceImpl.kt
+++ b/web/backend/communect/src/main/kotlin/com/example/communect/app/service/UserServiceImpl.kt
@@ -5,6 +5,7 @@ import com.example.communect.domain.repository.UserRepository
 import com.example.communect.domain.service.UserService
 import org.apache.coyote.BadRequestException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
 import java.util.*
@@ -12,7 +13,8 @@ import java.util.*
 /** ユーザ処理実装クラス */
 @Service
 class UserServiceImpl(
-    @Autowired val userRepository: UserRepository
+    @Autowired val userRepository: UserRepository,
+    @Autowired val passwordEncoder: PasswordEncoder
 ): UserService {
     private val apikeyService = ApikeyService()
     /**
@@ -40,8 +42,9 @@ class UserServiceImpl(
      */
     override fun addUser(user: UserIns): User {
         if(userRepository.findByUserName(user.userName) != null) throw BadRequestException("username is used")
+        val insUser = user.copy(password = passwordEncoder.encode(user.password))
         val apikey = apikeyService.generateApiKey()
-        return userRepository.insertUser(user, apikey)
+        return userRepository.insertUser(insUser, apikey)
     }
 
     /**

--- a/web/backend/communect/src/main/kotlin/com/example/communect/ui/form/UserForm.kt
+++ b/web/backend/communect/src/main/kotlin/com/example/communect/ui/form/UserForm.kt
@@ -97,8 +97,6 @@ data class DeleteGroupUserRequest(val groupUserId: String)
 /** グループユーザ更新リクエスト */
 data class UpdGroupUserRequest(
     /** グループユーザID */
-    @get:NullOrNotBlank
-    @get:Size(max = 20)
     val groupUserId: String,
     /** 表示名 */
     @get:NullOrNotBlank

--- a/web/communect-delete.sh
+++ b/web/communect-delete.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+echo "---comunect---"
+
+cd ./frontend
+echo "---frontend---"
+docker-compose down --rmi all --volumes --remove-orphans
+echo "---frontend---"
+
+cd ../backend
+echo "---backend---"
+docker-compose down --rmi all --volumes --remove-orphans
+echo "---backend---"
+
+cd ../db
+echo "---db---"
+docker-compose down --rmi all --volumes --remove-orphans
+echo "---db---"
+
+cd ../nginx-proxy
+echo "---nginx-proxy---"
+docker-compose down --rmi all --volumes --remove-orphans
+echo "---nginx-proxy---"
+
+echo "---comunect---"

--- a/web/communect-down.sh
+++ b/web/communect-down.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 echo "---comunect---"
 
-cd ../frontend
+cd ./frontend
 echo "---frontend---"
 docker compose down
 echo "---frontend---"
@@ -16,7 +16,7 @@ echo "---db---"
 docker compose down
 echo "---db---"
 
-cd ./nginx-proxy
+cd ../nginx-proxy
 echo "---nginx-proxy---"
 docker compose down
 echo "---nginx-proxy---"

--- a/web/frontend/communect/src/AccountProfile.jsx
+++ b/web/frontend/communect/src/AccountProfile.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import UserProfile from "./components/UserProfile";
+import Logout from "./Logout";
 import "./css/sidebar.css";
 import "./css/main.css";
 
@@ -39,6 +40,7 @@ function AccountProfile() {
             <a href="/group" className="nav-link">Groups</a>
             <h5 className="mt-3">Account</h5>
           </nav>
+          <Logout />
         </aside>
 
         {/* Resizer */}

--- a/web/frontend/communect/src/AccountProfile.jsx
+++ b/web/frontend/communect/src/AccountProfile.jsx
@@ -14,7 +14,6 @@ function AccountProfile() {
 
   return (
     <div className="container-fluid vh-100 overflow-hidden p-0">
-      {/* Header */}
       <header className="h-20 navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
         <div className="container-fluid">
           <div className="d-flex align-items-center">
@@ -23,9 +22,7 @@ function AccountProfile() {
         </div>
       </header>
 
-      {/* Main Content */}
       <main className="h-80 d-flex">
-        {/* Sidebar */}
         <aside
           className="bg-light p-3 border-end"
           style={{
@@ -43,7 +40,6 @@ function AccountProfile() {
           <Logout />
         </aside>
 
-        {/* Resizer */}
         <div
           className="resizer"
           onMouseDown={(e) => {
@@ -53,13 +49,11 @@ function AccountProfile() {
           }}
         ></div>
 
-        {/* Main Content */}
         <div className="maincontent flex-grow-1 ps-5 reset">
           <UserProfile />
         </div>
       </main>
 
-      {/* Sidebar Toggle Button */}
       <div
         className="sidebar-toggle-icon"
         onClick={toggleSidebar}

--- a/web/frontend/communect/src/AccountRegister.jsx
+++ b/web/frontend/communect/src/AccountRegister.jsx
@@ -1,84 +1,124 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import Granim from 'granim';
+import { Form, Button, Container, Card } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+import './css/accountRegister.css';
 
 const AccountRegister = () => {
-    const [formData, setFormData] = useState({
-        userName: '',
-        nickName: '',
-        password: '',
-        email: ''
+  const [formData, setFormData] = useState({
+    userName: '',
+    nickName: '',
+    password: '',
+    email: '',
+  });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 背景アニメーションの初期化
+    new Granim({
+      element: '#canvas-basic',
+      direction: 'diagonal',
+      isPausedWhenNotInView: true,
+      states: {
+        'default-state': {
+          gradients: [
+            ['#FF9966', '#FF5E62'],
+            ['#00F260', '#0575E6'],
+            ['#e1eec3', '#f05053'],
+          ],
+          transitionSpeed: 2400,
+        },
+      },
     });
+  }, []);
 
-    const handleChange = (e) => {
-        const { name, value } = e.target;
-        setFormData({
-            ...formData,
-            [name]: value
-        });
-    };
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
+    });
+  };
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        try {
-            const response = await axios.post(import.meta.env.VITE_API_URL + "/user", formData);
-            console.log('登録成功:', response.data);
-        } catch (error) {
-            console.error('登録失敗:', error);
-        }
-    };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await axios.post(import.meta.env.VITE_API_URL + '/user', formData, {
+        withCredentials: true
+      });
+      console.log('登録成功:', response.data);
+      navigate('/login');
+    } catch (error) {
+      if (error.response) {
+        console.error('登録失敗:', error.response.data);
+        alert(`登録エラー: ${error.response.data.message || '不明なエラー'}`);
+      } else if (error.request) {
+        console.error('サーバーが応答しません:', error.request);
+        alert('サーバーが応答しません。ネットワークを確認してください。');
+      } else {
+        console.error('エラーが発生しました:', error.message);
+        alert(`エラー: ${error.message}`);
+      }
+    }
+  };
 
-    return (
-        <div className="register-container">
-            <h1 className="title">新規登録</h1>
-            <form onSubmit={handleSubmit} className="register-form">
-                <div className="form-group">
-                    <label className="form-label">ユーザーネーム</label>
-                    <input
-                        type="text"
-                        name="userName"
-                        value={formData.username}
-                        onChange={handleChange}
-                        className="form-input"
-                        required
-                    />
-                </div>
-                <div className="form-group">
-                    <label className="form-label">ニックネーム</label>
-                    <input
-                        type="text"
-                        name="nickName"
-                        value={formData.nickname}
-                        onChange={handleChange}
-                        className="form-input"
-                        required
-                    />
-                <div className="form-group">
-                    <label className="form-label">パスワード</label>
-                    <input
-                        type="password"
-                        name="password"
-                        value={formData.password}
-                        onChange={handleChange}
-                        className="form-input"
-                        required
-                    />
-                </div>
-                </div>
-                <div className="form-group">
-                    <label className="form-label">メールアドレス</label>
-                    <input
-                        type="email"
-                        name="email"
-                        value={formData.email}
-                        onChange={handleChange}
-                        className="form-input"
-                        required
-                    />
-                </div>
-                <button type="submit" className="register-button">登録</button>
-            </form>
-        </div>
-    );
+  return (
+    <Container
+      fluid
+      className="vh-100 d-flex justify-content-center align-items-center position-relative"
+    >
+      <canvas id="canvas-basic" className="position-absolute w-100 h-100" />
+      <Card className="p-4" style={{ width: '100%', maxWidth: '500px', zIndex: 1 }}>
+        <h2 className="text-center mb-4">新規登録</h2>
+        <Form onSubmit={handleSubmit}>
+          <Form.Group className="mb-3" controlId="userName">
+            <Form.Label>ユーザー名</Form.Label>
+            <Form.Control
+              type="text"
+              name="userName"
+              value={formData.userName}
+              onChange={handleChange}
+              required
+            />
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="nickName">
+            <Form.Label>ニックネーム</Form.Label>
+            <Form.Control
+              type="text"
+              name="nickName"
+              value={formData.nickName}
+              onChange={handleChange}
+              required
+            />
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="password">
+            <Form.Label>パスワード</Form.Label>
+            <Form.Control
+              type="password"
+              name="password"
+              value={formData.password}
+              onChange={handleChange}
+              required
+            />
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="email">
+            <Form.Label>メールアドレス</Form.Label>
+            <Form.Control
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              required
+            />
+          </Form.Group>
+          <Button variant="primary" type="submit" className="w-100">
+            登録
+          </Button>
+        </Form>
+      </Card>
+    </Container>
+  );
 };
 
 export default AccountRegister;

--- a/web/frontend/communect/src/AccountRegister.jsx
+++ b/web/frontend/communect/src/AccountRegister.jsx
@@ -44,20 +44,16 @@ const AccountRegister = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(import.meta.env.VITE_API_URL + '/user', formData, {
+      await axios.post(import.meta.env.VITE_API_URL + '/user', formData, {
         withCredentials: true
       });
-      console.log('登録成功:', response.data);
       navigate('/login');
     } catch (error) {
       if (error.response) {
-        console.error('登録失敗:', error.response.data);
         alert(`登録エラー: ${error.response.data.message || '不明なエラー'}`);
       } else if (error.request) {
-        console.error('サーバーが応答しません:', error.request);
         alert('サーバーが応答しません。ネットワークを確認してください。');
       } else {
-        console.error('エラーが発生しました:', error.message);
         alert(`エラー: ${error.message}`);
       }
     }

--- a/web/frontend/communect/src/DirectMessage.jsx
+++ b/web/frontend/communect/src/DirectMessage.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
+import Logout from "./Logout";
+import DirectMessageTalk from "./components/DirectMessageTalk";
 import "./css/sidebar.css";
 import "./css/main.css";
-import DirectMessageTalk from "./components/DirectMessageTalk";
 
 function DirectMessage() {
     const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -44,6 +45,7 @@ function DirectMessage() {
                       <a href="/group" className ="nav-link">Groups</a>
                       <a href="/account" className="nav-link">Account</a>
                     </nav>
+                    <Logout />
                   </aside>
                   <div
                     className="resizer"

--- a/web/frontend/communect/src/Group.jsx
+++ b/web/frontend/communect/src/Group.jsx
@@ -215,7 +215,7 @@ function Group() {
           onShowMembers={handleShowMembers}
           onOpenTalk={handleOpenTalk}
         />
-        <div className="maincontent flex-grow-1 ps-5 reset">
+        <div className="maincontent flex-grow-1 reset">
           {isGroupTalk && talkGroup ? (
             <GroupTalk group={talkGroup} onBack={handleBackFromTalk} currentGroup={currentGroup} />
           ) : (

--- a/web/frontend/communect/src/Group.jsx
+++ b/web/frontend/communect/src/Group.jsx
@@ -75,7 +75,6 @@ function Group() {
   };
 
   useEffect(() => {
-    // Fetch groups from the API
     const fetchGroups = async () => {
       try {
         const response = await axios.get(
@@ -113,6 +112,14 @@ function Group() {
     }));
   };
 
+  /* 作成関連 */
+  const handleAddGroup = (newGroup) => {
+    setGroups((prevGroups) => {
+      const updatedGroups = [...prevGroups, newGroup]; 
+      return buildHierarchy(updatedGroups);
+    });
+  };  
+
   /* 編集関連 */
   const handleEditGroup = (group) => {
     setEditModalGroup(group);
@@ -144,7 +151,6 @@ function Group() {
       return filterGroups(prevGroups);
     });
   
-    // 削除されたグループが現在選択中ならリセット
     if (currentGroup && currentGroup.groupId === deletedGroupId) {
       setCurrentGroup(null);
       setBreadcrumb([]);
@@ -228,7 +234,7 @@ function Group() {
       {showModal && (
         <div className="modal-overlay">
           <GroupCreate
-            onSubmit={handleFormSubmit}
+            onSubmit={handleAddGroup}
             currentGroup={currentGroup}
             toggleModal={toggleModal}
           />

--- a/web/frontend/communect/src/Group.jsx
+++ b/web/frontend/communect/src/Group.jsx
@@ -129,10 +129,20 @@ function Group() {
     setEditModalGroup(null); 
   };
 
-  const handleUpdateGroup = (groupId, updatedData) => {
+  const handleUpdateGroup = (groupId, newName) => {
     setGroups((prevGroups) =>
       prevGroups.map((group) =>
-        group.groupId === groupId ? { ...group, ...updatedData } : group
+        group.groupId === groupId ? { ...group, groupName: newName } : group
+      )
+    );
+  
+    if (currentGroup && currentGroup.groupId === groupId) {
+      setCurrentGroup((prev) => ({ ...prev, groupName: newName }));
+    }
+  
+    setBreadcrumb((prevBreadcrumb) =>
+      prevBreadcrumb.map((group) =>
+        group.groupId === groupId ? { ...group, groupName: newName } : group
       )
     );
   };

--- a/web/frontend/communect/src/Login.jsx
+++ b/web/frontend/communect/src/Login.jsx
@@ -44,7 +44,6 @@ function Login() {
       const data = text ? JSON.parse(text) : null;
 
       if (response.ok) {
-        console.log('ログイン成功:', data);
 
         if (data?.sessionId) {
           localStorage.setItem('SESSIONID', data.sessionId);

--- a/web/frontend/communect/src/Login.jsx
+++ b/web/frontend/communect/src/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Button, Form, Container, Alert } from 'react-bootstrap';
+import { Button, Form, Container, Alert, Card } from 'react-bootstrap';
 import './css/login.css';
 import Granim from 'granim';
 import { useNavigate } from 'react-router-dom';
@@ -11,7 +11,6 @@ function Login() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // 背景アニメーションの初期化
     new Granim({
       element: '#canvas-basic',
       direction: 'diagonal',
@@ -47,12 +46,10 @@ function Login() {
       if (response.ok) {
         console.log('ログイン成功:', data);
 
-        // セッションIDなどを保存したい場合
         if (data?.sessionId) {
           localStorage.setItem('SESSIONID', data.sessionId);
         }
 
-        // /group ページに遷移
         navigate('/group');
       } else {
         setError(data?.error || 'サーバーエラーが発生しました。');
@@ -62,44 +59,48 @@ function Login() {
       setError('ネットワークエラーが発生しました。再試行してください。');
     }
   };
-  
 
   return (
     <Container fluid className="vh-100 d-flex justify-content-center align-items-center position-relative">
-      {/* 背景用のCanvas */}
       <canvas id="canvas-basic" className="position-absolute w-100 h-100" />
-
-      {/* ログインフォーム */}
-      <div className="card p-5" style={{ width: '100%', maxWidth: '400px', zIndex: 1 }}>
-        <h2>ログイン</h2>
-        {error && <Alert variant="danger">{error}</Alert>}
-
-        <Form onSubmit={handleLogin}>
-          <Form.Group className="mb-3" controlId="username">
-            <Form.Label>ユーザー名</Form.Label>
-            <Form.Control
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              required
-            />
-          </Form.Group>
-
-          <Form.Group className="mb-3" controlId="password">
-            <Form.Label>パスワード</Form.Label>
-            <Form.Control
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </Form.Group>
-
-          <Button variant="primary" type="submit" className="w-100">
-            ログイン
-          </Button>
-        </Form>
-      </div>
+      <Card className="p-4 shadow-lg rounded" style={{ width: '100%', maxWidth: '400px', zIndex: 1 }}>
+        <Card.Body>
+          <h2 className="text-center mb-4">ログイン</h2>
+          {error && <Alert variant="danger">{error}</Alert>}
+          <Form onSubmit={handleLogin}>
+            <Form.Group className="mb-3" controlId="username">
+              <Form.Label>ユーザー名</Form.Label>
+              <Form.Control
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="ユーザー名を入力してください"
+                required
+              />
+            </Form.Group>
+            <Form.Group className="mb-3" controlId="password">
+              <Form.Label>パスワード</Form.Label>
+              <Form.Control
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="パスワードを入力してください"
+                required
+              />
+            </Form.Group>
+            <Button variant="outline-primary" type="submit" className="w-100">
+              ログイン
+            </Button>
+            <Button
+              variant="outline-secondary"
+              className="w-100 mt-3"
+              onClick={() => navigate('/register')}
+            >
+              新規登録
+            </Button>
+          </Form>
+        </Card.Body>
+      </Card>
     </Container>
   );
 }

--- a/web/frontend/communect/src/components/GroupContact.jsx
+++ b/web/frontend/communect/src/components/GroupContact.jsx
@@ -36,6 +36,7 @@ function GroupContact({ groupName, hasPermission, groupId }) {
       setLoading(false);
     }
   };
+  
 
   // SSE接続
   useEffect(() => {
@@ -134,7 +135,7 @@ function GroupContact({ groupName, hasPermission, groupId }) {
   // 投稿編集
   const handleEditPost = async (contactId, updatedData) => {
     if (isSubmitting) return;
-
+  
     setIsSubmitting(true);
     try {
       const response = await fetch(
@@ -146,9 +147,10 @@ function GroupContact({ groupName, hasPermission, groupId }) {
           body: JSON.stringify(updatedData),
         }
       );
-
+  
       if (!response.ok) throw new Error("投稿の編集に失敗しました。");
-      fetchPosts(); // 最新の投稿を取得
+  
+      fetchPosts(); 
     } catch (err) {
       alert(`エラー: ${err.message}`);
     } finally {

--- a/web/frontend/communect/src/components/GroupContact.jsx
+++ b/web/frontend/communect/src/components/GroupContact.jsx
@@ -158,7 +158,8 @@ function GroupContact({ groupName, hasPermission, groupId }) {
           body: JSON.stringify(updatedData),
         }
       );
-  
+
+      window.confirm("既にリアクションがある場合、リアクションは消えますが、よろしいですか？");
       if (!response.ok) throw new Error("投稿の編集に失敗しました。");
   
       const updatedPost = await response.json();

--- a/web/frontend/communect/src/components/GroupContact.jsx
+++ b/web/frontend/communect/src/components/GroupContact.jsx
@@ -15,6 +15,7 @@ function GroupContact({ groupName, hasPermission, groupId }) {
   const [selectedPost, setSelectedPost] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [notifications, setNotifications] = useState([]);
+  const [reactedPosts, setReactedPosts] = useState(new Set());
 
   // 投稿一覧を取得
   const fetchPosts = async () => {

--- a/web/frontend/communect/src/components/GroupContact.jsx
+++ b/web/frontend/communect/src/components/GroupContact.jsx
@@ -15,8 +15,7 @@ function GroupContact({ groupName, hasPermission, groupId }) {
   const [selectedPost, setSelectedPost] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [notifications, setNotifications] = useState([]);
-  const [reactedPosts, setReactedPosts] = useState(new Set());
-
+  
   // 投稿一覧を取得
   const fetchPosts = async () => {
     setLoading(true);
@@ -55,7 +54,6 @@ function GroupContact({ groupName, hasPermission, groupId }) {
 
       // 新規データ追加イベント
       sse.addEventListener("post", (event) => {
-        console.log("POSTイベント:", event.data);
         try {
           const data = JSON.parse(event.data);
       
@@ -85,7 +83,6 @@ function GroupContact({ groupName, hasPermission, groupId }) {
 
       // データ更新イベント
       sse.addEventListener("update", (event) => {
-        console.log("UPDATEイベント:", event.data);
         try {
           const data = JSON.parse(event.data);
           const contact = data.contact || {};
@@ -109,7 +106,6 @@ function GroupContact({ groupName, hasPermission, groupId }) {
 
       // データ削除イベント
       sse.addEventListener("delete", (event) => {
-        console.log("DELETEイベント:", event.data);
         try {
           const data = JSON.parse(event.data);
           setPosts((prevPosts) =>

--- a/web/frontend/communect/src/components/GroupContact.jsx
+++ b/web/frontend/communect/src/components/GroupContact.jsx
@@ -66,7 +66,7 @@ function GroupContact({ groupName, hasPermission, groupId }) {
           }
       
           const validatedChoices = Array.isArray(contact.choices) && contact.choices.every(c => typeof c === 'object' && c.choice)
-            ? contact.choices
+            ? contact.choices.reverse()
             : [];
           
           setPosts((prevPosts) => [...prevPosts, contact]);

--- a/web/frontend/communect/src/components/GroupCreate.jsx
+++ b/web/frontend/communect/src/components/GroupCreate.jsx
@@ -21,29 +21,28 @@ function GroupCreate({ onSubmit, currentGroup, toggleModal }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-
+  
     if (!groupName.trim()) {
       setError("グループ名は必須です。");
       return;
     }
-
+  
     const newGroup = {
       name: groupName.trim(),
       above: parentGroupId || null,
       users: addedUsers.map((user) => user.userId),
     };
-
+  
     try {
       const response = await axios.post(
-        `${import.meta.env.VITE_API_URL}/group`, newGroup ,{
+        `${import.meta.env.VITE_API_URL}/group`, newGroup, {
           withCredentials: true,
           credentials: "include",
         }
       );
-      alert("グループが作成されました。再読み込みを行ってください。");
-
-      if (onSubmit) onSubmit(response.data);
-
+  
+      if (onSubmit) onSubmit(response.data.group); 
+  
       setGroupName("");
       setParentGroupId(null);
       setAddedUsers([]);

--- a/web/frontend/communect/src/components/GroupTalk.jsx
+++ b/web/frontend/communect/src/components/GroupTalk.jsx
@@ -76,7 +76,7 @@ const TalkRoom = ({ currentGroup, onSelectTalk }) => {
   
       console.log("新しいSSE接続を開始します:", selectedTalk);
       sse = new EventSource(
-        `${import.meta.env.VITE_API_URL}/message/sse?talkId=${selectedTalk}`,
+        `${import.meta.env.VITE_API_URL}/message/sse`,
         {
           withCredentials: true,
           credentials: "include",

--- a/web/frontend/communect/src/components/GroupTalk.jsx
+++ b/web/frontend/communect/src/components/GroupTalk.jsx
@@ -71,12 +71,12 @@ const TalkRoom = ({ currentGroup, onSelectTalk }) => {
     const connectSSE = () => {
       if (sse) {
         console.log("既存のSSE接続を閉じます");
-        sse.close(); // 既存の接続をクローズ
+        sse.close(); // 既存接続を閉じる
       }
   
       console.log("新しいSSE接続を開始します:", selectedTalk);
       sse = new EventSource(
-        `${import.meta.env.VITE_API_URL}/message/sse?talkId=${selectedTalk}`,
+        `${import.meta.env.VITE_API_URL}/message/sse`,
         {
           withCredentials: true,
           credentials: "include",

--- a/web/frontend/communect/src/components/GroupTalk.jsx
+++ b/web/frontend/communect/src/components/GroupTalk.jsx
@@ -76,7 +76,7 @@ const TalkRoom = ({ currentGroup, onSelectTalk }) => {
   
       console.log("新しいSSE接続を開始します:", selectedTalk);
       sse = new EventSource(
-        `${import.meta.env.VITE_API_URL}/message/sse`,
+        `${import.meta.env.VITE_API_URL}/message/sse?talkId=${selectedTalk}`,
         {
           withCredentials: true,
           credentials: "include",
@@ -165,9 +165,10 @@ const TalkRoom = ({ currentGroup, onSelectTalk }) => {
   const handleSendMessage = (newMessage) => {
     setMessages((prevMessages) => {
       if (prevMessages.some((msg) => msg.messageId === newMessage.messageId)) {
-        return prevMessages; // 重複メッセージを無視
+        console.log("重複無視");
+        return prevMessages; // 重複を無視
       }
-      return [...prevMessages, newMessage];
+      return [...prevMessages, newMessage]; // メッセージを末尾に追加
     });
   };
   

--- a/web/frontend/communect/src/components/GroupTalk.jsx
+++ b/web/frontend/communect/src/components/GroupTalk.jsx
@@ -49,7 +49,7 @@ const TalkRoom = ({ currentGroup, onSelectTalk }) => {
           credentials: "include",
         }
       );
-      setMessages(response.data.messages || []);
+      setMessages(response.data.messages.reverse() || []);
     } catch (err) {
       setError("メッセージ一覧の取得に失敗しました。");
     } finally {

--- a/web/frontend/communect/src/components/Sidebar.jsx
+++ b/web/frontend/communect/src/components/Sidebar.jsx
@@ -14,7 +14,7 @@ function Sidebar({
   toggleModal,
   error,
   currentGroup,
-  handleGroupDelete,
+  handleDeleteGroup,
   onEditGroup,
   onShowMembers,
   onOpenTalk,
@@ -49,7 +49,7 @@ function Sidebar({
                     toggleGroup={toggleGroup}
                     handleGroupClick={handleGroupClick}
                     currentGroup={currentGroup}
-                    onDeleteGroup={handleGroupDelete}
+                    onDeleteGroup={handleDeleteGroup}
                     onEditGroup={onEditGroup}
                     onShowMembers={onShowMembers}
                     onOpenTalk={onOpenTalk}

--- a/web/frontend/communect/src/components/contact/Notifications.jsx
+++ b/web/frontend/communect/src/components/contact/Notifications.jsx
@@ -3,6 +3,8 @@ import { Toast, ToastContainer, Button } from "react-bootstrap";
 
 async function handleNotificationReaction(postId, choiceId = null) {
   try {
+    const requestBody = choiceId !== null ? { choiceId } : {};
+    
     const response = await fetch(
       import.meta.env.VITE_API_URL + `/contact/${postId}/reaction`,
       {
@@ -10,9 +12,8 @@ async function handleNotificationReaction(postId, choiceId = null) {
         headers: {
           "Content-Type": "application/json",
         },
-        withCredentials: true,
         credentials: "include",
-        body: JSON.stringify({ choiceId }),
+        body: JSON.stringify(requestBody),
       }
     );
 
@@ -35,7 +36,7 @@ function Notifications({ notifications, onRemoveNotification }) {
           autohide
           delay={10000}
           onClose={() => onRemoveNotification(notif.postId)}
-          className="noticications"
+          className="notifications"
         >
           <Toast.Header>
             <strong className="me-auto">
@@ -56,7 +57,7 @@ function Notifications({ notifications, onRemoveNotification }) {
                   variant="primary"
                   size="sm"
                   onClick={async () => {
-                    await handleNotificationReaction(notif.postId,choiceId);
+                    await handleNotificationReaction(notif.postId, null);
                     onRemoveNotification(notif.postId);
                   }}
                 >
@@ -80,8 +81,7 @@ function Notifications({ notifications, onRemoveNotification }) {
                           onRemoveNotification(notif.postId);
                         }}
                       >
-                        {choiceObj.choice || "不明な選択肢"}{" "}
-                        {/* choiceを表示 */}
+                        {choiceObj.choice || "不明な選択肢"}
                       </Button>
                     ))}
                   </div>

--- a/web/frontend/communect/src/components/contact/Notifications.jsx
+++ b/web/frontend/communect/src/components/contact/Notifications.jsx
@@ -10,6 +10,7 @@ async function handleNotificationReaction(postId, choiceId = null) {
         headers: {
           "Content-Type": "application/json",
         },
+        withCredentials: true,
         credentials: "include",
         body: JSON.stringify({ choiceId }),
       }
@@ -55,7 +56,7 @@ function Notifications({ notifications, onRemoveNotification }) {
                   variant="primary"
                   size="sm"
                   onClick={async () => {
-                    await handleNotificationReaction(notif.postId, "👍");
+                    await handleNotificationReaction(notif.postId,choiceId);
                     onRemoveNotification(notif.postId);
                   }}
                 >
@@ -75,7 +76,7 @@ function Notifications({ notifications, onRemoveNotification }) {
                           await handleNotificationReaction(
                             notif.postId,
                             choiceObj.choiceId
-                          ); // choiceIdを利用
+                          );
                           onRemoveNotification(notif.postId);
                         }}
                       >

--- a/web/frontend/communect/src/components/contact/Notifications.jsx
+++ b/web/frontend/communect/src/components/contact/Notifications.jsx
@@ -4,7 +4,6 @@ import { Toast, ToastContainer, Button } from "react-bootstrap";
 async function handleNotificationReaction(postId, choiceId = null) {
   try {
     const requestBody = choiceId !== null ? { choiceId } : {};
-    
     const response = await fetch(
       import.meta.env.VITE_API_URL + `/contact/${postId}/reaction`,
       {
@@ -12,6 +11,7 @@ async function handleNotificationReaction(postId, choiceId = null) {
         headers: {
           "Content-Type": "application/json",
         },
+        withCredentials: true,
         credentials: "include",
         body: JSON.stringify(requestBody),
       }
@@ -36,7 +36,7 @@ function Notifications({ notifications, onRemoveNotification }) {
           autohide
           delay={10000}
           onClose={() => onRemoveNotification(notif.postId)}
-          className="notifications"
+          className="noticications"
         >
           <Toast.Header>
             <strong className="me-auto">
@@ -82,6 +82,7 @@ function Notifications({ notifications, onRemoveNotification }) {
                         }}
                       >
                         {choiceObj.choice || "不明な選択肢"}
+                        {/* choiceを表示 */}
                       </Button>
                     ))}
                   </div>

--- a/web/frontend/communect/src/components/contact/PostFormModal.jsx
+++ b/web/frontend/communect/src/components/contact/PostFormModal.jsx
@@ -10,7 +10,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
-  
+
   useEffect(() => {
     if (initialData) {
       setFormData({
@@ -89,7 +89,6 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
       const newPost = await response.json();
 
       if (!initialData) {
-        // 新規投稿のみ即時反映
         onPostCreated(newPost);
       }
       onClose();
@@ -106,7 +105,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
         <Modal.Title>{initialData ? "投稿を編集" : "新規投稿"}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {error && <Alert variant="danger">{error}</Alert>}  {/* エラーメッセージを表示 */}
+        {error && <Alert variant="danger">{error}</Alert>}
         <Form>
           <Form.Group>
             <Form.Label>メッセージ</Form.Label>

--- a/web/frontend/communect/src/components/contact/PostFormModal.jsx
+++ b/web/frontend/communect/src/components/contact/PostFormModal.jsx
@@ -58,11 +58,22 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
       return;
     }
 
-    const requestData = { ...formData, groupId };
+    let requestData = {
+      message: formData.message,
+      contactType: formData.contactType,
+      importance: formData.importance,
+      groupId,
+    };
+
+    if (formData.contactType === "CHOICE") {
+      requestData.choices = formData.choices;
+    }
 
     try {
       const response = await fetch(
-        `${import.meta.env.VITE_API_URL}/contact${initialData ? `/${initialData.contactId}` : ""}`,
+        `${import.meta.env.VITE_API_URL}/contact${
+          initialData ? `/${initialData.contactId}` : ""
+        }`,
         {
           method: initialData ? "PUT" : "POST",
           headers: { "Content-Type": "application/json" },
@@ -78,7 +89,6 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
         // 新規投稿のみ即時反映
         onPostCreated(newPost);
       }
-
       onClose();
     } catch (err) {
       alert(err.message);
@@ -159,7 +169,11 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
             <option value="HIGH">高</option>
           </select>
         </div>
-        <button className="btn btn-primary" onClick={handleSubmit} disabled={isSubmitting}>
+        <button
+          className="btn btn-primary"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+        >
           {initialData ? "保存" : "投稿"}
         </button>
       </div>

--- a/web/frontend/communect/src/components/contact/PostFormModal.jsx
+++ b/web/frontend/communect/src/components/contact/PostFormModal.jsx
@@ -5,7 +5,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
     message: "",
     contactType: "INFORM",
     importance: "LOW",
-    choices: ["", ""], // 初期状態で2つの選択肢を用意
+    choices: ["", ""],
   });
 
   useEffect(() => {
@@ -30,10 +30,13 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
   };
 
   const handleChoiceChange = (index, value) => {
-    const updatedChoices = [...formData.choices];
-    updatedChoices[index] = value;
-    setFormData((prev) => ({ ...prev, choices: updatedChoices }));
+    setFormData((prev) => {
+      const updatedChoices = [...prev.choices];
+      updatedChoices[index] = value;
+      return { ...prev, choices: updatedChoices };
+    });
   };
+
 
   const addChoice = () => {
     setFormData((prev) => ({ ...prev, choices: [...prev.choices, ""] }));
@@ -68,7 +71,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
 
       if (!response.ok) throw new Error("投稿に失敗しました。");
       const newPost = await response.json();
-      onPostCreated(newPost); // 新規投稿後に更新
+      onPostCreated(newPost);
       onClose();
     } catch (err) {
       alert(err.message);
@@ -141,6 +144,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
             onChange={handleInputChange}
             className="form-control"
           >
+            <option value="SAFE">最低</option>
             <option value="LOW">低</option>
             <option value="MEDIUM">中</option>
             <option value="HIGH">高</option>

--- a/web/frontend/communect/src/components/contact/PostFormModal.jsx
+++ b/web/frontend/communect/src/components/contact/PostFormModal.jsx
@@ -7,6 +7,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
     importance: "LOW",
     choices: ["", ""],
   });
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (initialData) {
@@ -22,7 +23,6 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
       });
     }
   }, [initialData]);
-  
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -37,7 +37,6 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
     });
   };
 
-
   const addChoice = () => {
     setFormData((prev) => ({ ...prev, choices: [...prev.choices, ""] }));
   };
@@ -50,8 +49,12 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
   };
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
     if (formData.contactType === "CHOICE" && formData.choices.length < 2) {
       alert("選択肢は2つ以上入力してください。");
+      setIsSubmitting(false);
       return;
     }
 
@@ -63,7 +66,6 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
         {
           method: initialData ? "PUT" : "POST",
           headers: { "Content-Type": "application/json" },
-          withcredentials: true,
           credentials: "include",
           body: JSON.stringify(requestData),
         }
@@ -71,10 +73,17 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
 
       if (!response.ok) throw new Error("投稿に失敗しました。");
       const newPost = await response.json();
-      onPostCreated(newPost);
+
+      if (!initialData) {
+        // 新規投稿のみ即時反映
+        onPostCreated(newPost);
+      }
+
       onClose();
     } catch (err) {
       alert(err.message);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -150,7 +159,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
             <option value="HIGH">高</option>
           </select>
         </div>
-        <button className="btn btn-primary" onClick={handleSubmit}>
+        <button className="btn btn-primary" onClick={handleSubmit} disabled={isSubmitting}>
           {initialData ? "保存" : "投稿"}
         </button>
       </div>

--- a/web/frontend/communect/src/components/contact/PostFormModal.jsx
+++ b/web/frontend/communect/src/components/contact/PostFormModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Modal, Form, Button, Alert, Spinner } from "react-bootstrap";
 
 function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
   const [formData, setFormData] = useState({
@@ -8,6 +9,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
     choices: ["", ""],
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState("");  // error stateを追加
 
   useEffect(() => {
     if (initialData) {
@@ -51,9 +53,10 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
   const handleSubmit = async () => {
     if (isSubmitting) return;
     setIsSubmitting(true);
+    setError(""); // エラーメッセージをリセット
 
     if (formData.contactType === "CHOICE" && formData.choices.length < 2) {
-      alert("選択肢は2つ以上入力してください。");
+      setError("選択肢は2つ以上入力してください。");  // エラーメッセージをセット
       setIsSubmitting(false);
       return;
     }
@@ -91,93 +94,79 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
       }
       onClose();
     } catch (err) {
-      alert(err.message);
+      setError(err.message);  // エラーメッセージをセット
     } finally {
       setIsSubmitting(false);
     }
   };
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content" style={{ maxWidth: "400px" }}>
-        <button className="btn-close" onClick={onClose}></button>
-        <h2>{initialData ? "投稿を編集" : "新規投稿"}</h2>
-        <div className="form-group">
-          <label>メッセージ</label>
-          <textarea
-            className="form-control"
-            name="message"
-            value={formData.message}
-            onChange={handleInputChange}
-          />
-        </div>
-        <div className="form-group">
-          <label>連絡タイプ</label>
-          <select
-            name="contactType"
-            value={formData.contactType}
-            onChange={handleInputChange}
-            className="form-control"
-          >
-            <option value="INFORM">周知連絡</option>
-            <option value="CONFIRM">確認連絡</option>
-            <option value="CHOICE">多肢連絡</option>
-          </select>
-        </div>
-        {formData.contactType === "CHOICE" && (
-          <div className="form-group">
-            <label>選択肢</label>
-            {formData.choices.map((choice, index) => (
-              <div key={index} className="d-flex align-items-center mb-2">
-                <input
-                  type="text"
-                  className="form-control me-2"
-                  value={typeof choice === "string" ? choice : ""}
-                  onChange={(e) => handleChoiceChange(index, e.target.value)}
-                />
-                {index >= 2 && (
-                  <button
-                    type="button"
-                    className="btn btn-danger btn-sm"
-                    onClick={() => removeChoice(index)}
-                  >
-                    削除
-                  </button>
-                )}
-              </div>
-            ))}
-            <button
-              type="button"
-              className="btn btn-secondary btn-sm mt-2"
-              onClick={addChoice}
-            >
-              選択肢を追加
-            </button>
-          </div>
-        )}
-        <div className="form-group">
-          <label>重要度</label>
-          <select
-            name="importance"
-            value={formData.importance}
-            onChange={handleInputChange}
-            className="form-control"
-          >
-            <option value="SAFE">最低</option>
-            <option value="LOW">低</option>
-            <option value="MEDIUM">中</option>
-            <option value="HIGH">高</option>
-          </select>
-        </div>
-        <button
-          className="btn btn-primary"
-          onClick={handleSubmit}
-          disabled={isSubmitting}
-        >
-          {initialData ? "保存" : "投稿"}
-        </button>
-      </div>
-    </div>
+    <Modal show onHide={onClose} centered size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>{initialData ? "投稿を編集" : "新規投稿"}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {error && <Alert variant="danger">{error}</Alert>}  {/* エラーメッセージを表示 */}
+        <Form>
+          <Form.Group>
+            <Form.Label>メッセージ</Form.Label>
+            <Form.Control
+              as="textarea"
+              name="message"
+              value={formData.message}
+              onChange={handleInputChange}
+            />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>連絡タイプ</Form.Label>
+            <Form.Select name="contactType" value={formData.contactType} onChange={handleInputChange}>
+              <option value="INFORM">周知連絡</option>
+              <option value="CONFIRM">確認連絡</option>
+              <option value="CHOICE">多肢連絡</option>
+            </Form.Select>
+          </Form.Group>
+          {formData.contactType === "CHOICE" && (
+            <Form.Group>
+              <Form.Label>選択肢</Form.Label>
+              {formData.choices.map((choice, index) => (
+                <div key={index} className="d-flex align-items-center mb-2">
+                  <Form.Control
+                    type="text"
+                    value={typeof choice === "string" ? choice : ""}
+                    onChange={(e) => handleChoiceChange(index, e.target.value)}
+                  />
+                  {index >= 2 && (
+                    <Button className="text-wrap" variant="danger" size="sm" onClick={() => removeChoice(index)}>
+                      削除
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <Button variant="secondary" size="sm" className="mt-2" onClick={addChoice}>
+                選択肢を追加
+              </Button>
+            </Form.Group>
+          )}
+          <Form.Group>
+            <Form.Label>重要度</Form.Label>
+            <Form.Select name="importance" value={formData.importance} onChange={handleInputChange}>
+              <option value="SAFE">最低</option>
+              <option value="LOW">低</option>
+              <option value="MEDIUM">中</option>
+              <option value="HIGH">高</option>
+            </Form.Select>
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>
+          キャンセル
+        </Button>
+        <Button variant="primary" onClick={handleSubmit} disabled={isSubmitting}>
+          {isSubmitting ? <Spinner as="span" animation="border" size="sm" /> : initialData ? "保存" : "投稿"}
+        </Button>
+      </Modal.Footer>
+    </Modal>
   );
 }
 

--- a/web/frontend/communect/src/components/contact/PostFormModal.jsx
+++ b/web/frontend/communect/src/components/contact/PostFormModal.jsx
@@ -9,8 +9,8 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
     choices: ["", ""],
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState("");  // error stateを追加
-
+  const [error, setError] = useState("");
+  
   useEffect(() => {
     if (initialData) {
       setFormData({
@@ -53,10 +53,10 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
   const handleSubmit = async () => {
     if (isSubmitting) return;
     setIsSubmitting(true);
-    setError(""); // エラーメッセージをリセット
+    setError("");
 
     if (formData.contactType === "CHOICE" && formData.choices.length < 2) {
-      setError("選択肢は2つ以上入力してください。");  // エラーメッセージをセット
+      setError("選択肢は2つ以上入力してください。");
       setIsSubmitting(false);
       return;
     }
@@ -94,7 +94,7 @@ function PostFormModal({ onClose, groupId, onPostCreated, initialData }) {
       }
       onClose();
     } catch (err) {
-      setError(err.message);  // エラーメッセージをセット
+      setError(err.message);
     } finally {
       setIsSubmitting(false);
     }

--- a/web/frontend/communect/src/components/contact/PostList.jsx
+++ b/web/frontend/communect/src/components/contact/PostList.jsx
@@ -64,7 +64,7 @@ function PostList({
         throw new Error("リアクション送信に失敗しました。");
       }
     } catch (err) {
-      alert(`エラー: ${err.message}`);
+      alert(`再度リアクションすることはできません！`);
     }
   };
 

--- a/web/frontend/communect/src/components/contact/PostList.jsx
+++ b/web/frontend/communect/src/components/contact/PostList.jsx
@@ -28,15 +28,24 @@ function PostList({
   if (loading) return <p>読み込み中...</p>;
   if (posts.length === 0) return <p>まだ投稿がありません。</p>;
 
-  const handleReactionClick = async (contactId, contactType, choiceId = null) => {
+  const handleReactionClick = async (
+    contactId,
+    contactType,
+    choiceId = null
+  ) => {
+    if (reactedPosts.has(contactId)) {
+      alert("この投稿は既にリアクション済みです。");
+      return; // 既にリアクション済みの場合は処理を停止
+    }
+
     try {
       const body =
         contactType === "CHOICE"
-          ? JSON.stringify({ choiceId }) // CHOICE の場合
-          : JSON.stringify({ choiceId: null }); // CONFIRM の場合
+          ? JSON.stringify({ choiceId })
+          : JSON.stringify({ choiceId: null });
 
       const response = await fetch(
-        import.meta.env.VITE_API_URL + `/contact/${contactId}/reaction`,
+        `${import.meta.env.VITE_API_URL}/contact/${contactId}/reaction`,
         {
           method: "POST",
           headers: {
@@ -50,7 +59,7 @@ function PostList({
 
       if (response.status === 200) {
         alert("リアクションが送信されました！");
-        setReactedPosts((prev) => new Set([...prev, contactId])); // リアクション済みとして登録
+        setReactedPosts((prev) => new Set([...prev, contactId]));
       } else {
         throw new Error("リアクション送信に失敗しました。");
       }
@@ -65,13 +74,13 @@ function PostList({
 
   const handleEditComplete = (updatedData) => {
     onEditPost(editingPost.contactId, updatedData);
-    setEditingPost(null); // 編集モーダルを閉じる
+    setEditingPost(null);
   };
 
   return (
     <div className="group-contact-content px-5">
       {posts.map((post, index) => {
-        const isReacted = reactedPosts.has(post.contactId); // リアクション済みか判定
+        const isReacted = reactedPosts.has(post.contactId);
 
         return (
           <div
@@ -107,7 +116,8 @@ function PostList({
             {post.contactType === "CHOICE" && post.choices && (
               <div className="choices-section mt-3">
                 <h5>選択肢</h5>
-                {post.choices.map((choice) => {
+                {post.choices.map((choice, index) => {
+                  const isChoiceDisabled = reactedPosts.has(post.contactId); // 既にリアクション済みかどうか
                   return (
                     <div
                       key={`${post.contactId}-${choice.choiceId}`}
@@ -122,7 +132,7 @@ function PostList({
                             choice.choiceId
                           )
                         }
-                        disabled={isReacted} // リアクション済みなら無効化
+                        disabled={isChoiceDisabled}
                       >
                         {choice.choice}
                       </button>

--- a/web/frontend/communect/src/components/contact/PostList.jsx
+++ b/web/frontend/communect/src/components/contact/PostList.jsx
@@ -7,7 +7,6 @@ function PostList({
   error,
   loading,
   onFetchDetails,
-  reactions = [],
   onEditPost,
   onDeletePost,
 }) {
@@ -28,7 +27,11 @@ function PostList({
   if (loading) return <p>読み込み中...</p>;
   if (posts.length === 0) return <p>まだ投稿がありません。</p>;
 
-  const handleReactionClick = async (contactId, contactType, choiceId = null) => {
+  const handleReactionClick = async (
+    contactId,
+    contactType,
+    choiceId = null
+  ) => {
     if (reactedPosts.has(contactId)) {
       alert("この投稿は既にリアクション済みです。");
       return;
@@ -81,7 +84,9 @@ function PostList({
         return (
           <div
             key={`${post.contactId}-${index}`}
-            className={`group-contact-post px-5 ${importanceClass[post.importance] || ""}`}
+            className={`group-contact-post px-5 ${
+              importanceClass[post.importance] || ""
+            }`}
           >
             {post.importance === "LOW" && (
               <span className="badge bg-info">INFO</span>
@@ -96,15 +101,23 @@ function PostList({
             <p>{post.message}</p>
 
             {post.contactType === "CONFIRM" && (
-              <button
-                className="btn btn-outline-secondary mt-2"
-                onClick={() =>
-                  handleReactionClick(post.contactId, post.contactType)
-                }
-                disabled={isReacted}
-              >
-                <i class="bi bi-check2-circle"></i> 確認
-              </button>
+              <div className="d-flex flex-column align-items-start mt-2">
+                <button
+                  className="btn btn-outline-secondary mb-2"
+                  onClick={() =>
+                    handleReactionClick(post.contactId, post.contactType)
+                  }
+                  disabled={isReacted}
+                >
+                  <i className="bi bi-check2-circle"></i> 確認
+                </button>
+                <button
+                  className="btn btn-outline-info"
+                  onClick={() => onFetchDetails(post.contactId)}
+                >
+                  <i className="bi bi-eye me-2"></i> 詳細を確認する
+                </button>
+              </div>
             )}
 
             {post.contactType === "CHOICE" && post.choices && (
@@ -137,7 +150,7 @@ function PostList({
               </div>
             )}
 
-            {(post.contactType === "CONFIRM" || post.contactType === "CHOICE") && (
+            {(post.contactType === "CHOICE") && (
               <button
                 className="btn btn-outline-info mt-2"
                 onClick={() => onFetchDetails(post.contactId)}

--- a/web/frontend/communect/src/components/contact/PostList.jsx
+++ b/web/frontend/communect/src/components/contact/PostList.jsx
@@ -15,7 +15,7 @@ function PostList({
   const [selectedReactions, setSelectedReactions] = useState([]);
   const [selectedChoice, setSelectedChoice] = useState(null);
   const [editingPost, setEditingPost] = useState(null);
-  const [reactedPosts, setReactedPosts] = useState(new Set()); // リアクション済み投稿を追跡
+  const [reactedPosts, setReactedPosts] = useState(new Set());
 
   const importanceClass = {
     HIGH: "post-high-importance",
@@ -28,14 +28,10 @@ function PostList({
   if (loading) return <p>読み込み中...</p>;
   if (posts.length === 0) return <p>まだ投稿がありません。</p>;
 
-  const handleReactionClick = async (
-    contactId,
-    contactType,
-    choiceId = null
-  ) => {
+  const handleReactionClick = async (contactId, contactType, choiceId = null) => {
     if (reactedPosts.has(contactId)) {
       alert("この投稿は既にリアクション済みです。");
-      return; // 既にリアクション済みの場合は処理を停止
+      return;
     }
 
     try {
@@ -85,9 +81,7 @@ function PostList({
         return (
           <div
             key={`${post.contactId}-${index}`}
-            className={`group-contact-post px-5 ${
-              importanceClass[post.importance] || ""
-            }`}
+            className={`group-contact-post px-5 ${importanceClass[post.importance] || ""}`}
           >
             {post.importance === "LOW" && (
               <span className="badge bg-info">INFO</span>
@@ -103,13 +97,13 @@ function PostList({
 
             {post.contactType === "CONFIRM" && (
               <button
-                className="btn btn-secondary mt-2"
+                className="btn btn-outline-secondary mt-2"
                 onClick={() =>
                   handleReactionClick(post.contactId, post.contactType)
                 }
-                disabled={isReacted} // リアクション済みなら無効化
+                disabled={isReacted}
               >
-                確認
+                <i class="bi bi-check2-circle"></i> 確認
               </button>
             )}
 
@@ -117,7 +111,7 @@ function PostList({
               <div className="choices-section mt-3">
                 <h5>選択肢</h5>
                 {post.choices.map((choice, index) => {
-                  const isChoiceDisabled = reactedPosts.has(post.contactId); // 既にリアクション済みかどうか
+                  const isChoiceDisabled = reactedPosts.has(post.contactId);
                   return (
                     <div
                       key={`${post.contactId}-${choice.choiceId}`}
@@ -134,6 +128,7 @@ function PostList({
                         }
                         disabled={isChoiceDisabled}
                       >
+                        <i class="bi bi-check2-circle"></i>
                         {choice.choice}
                       </button>
                     </div>
@@ -142,27 +137,27 @@ function PostList({
               </div>
             )}
 
-            {(post.contactType === "CONFIRM" ||
-              post.contactType === "CHOICE") && (
+            {(post.contactType === "CONFIRM" || post.contactType === "CHOICE") && (
               <button
                 className="btn btn-outline-info mt-2"
                 onClick={() => onFetchDetails(post.contactId)}
               >
-                詳細を確認する
+                <i className="bi bi-eye me-2"></i> 詳細を確認する
               </button>
             )}
+
             <div className="d-flex justify-content-end">
               <button
                 className="btn btn-warning btn-sm me-2"
                 onClick={() => handleOpenEditModal(post)}
               >
-                編集
+                <i className="bi bi-pencil me-2"></i> 編集
               </button>
               <button
                 className="btn btn-outline-danger btn-sm"
                 onClick={() => onDeletePost(post.contactId)}
               >
-                削除
+                <i className="bi bi-trash me-2"></i> 削除
               </button>
             </div>
           </div>
@@ -181,8 +176,8 @@ function PostList({
         <PostFormModal
           onClose={() => setEditingPost(null)}
           groupId={editingPost.groupId}
-          onPostCreated={handleEditComplete} // 編集結果を適用
-          initialData={editingPost} // 初期データを渡す
+          onPostCreated={handleEditComplete}
+          initialData={editingPost}
         />
       )}
     </div>

--- a/web/frontend/communect/src/components/group/GroupTalkSidebar.jsx
+++ b/web/frontend/communect/src/components/group/GroupTalkSidebar.jsx
@@ -70,9 +70,9 @@ const TalkSidebar = ({
   };
 
   return (
-    <Col xs={3} className={`${styles["groupTalk-sidebar"]} p-0`}>
+    <Col xs={3} className={`${styles["groupTalk-sidebar"]} px-3 py-2`}>
       <div className="d-flex justify-content-between align-items-center">
-        <h5>トークルーム一覧</h5>
+        <h5 className="text-primary border-bottom border-info">トークルーム一覧</h5>
         <Button
           variant="link"
           className="text-primary"

--- a/web/frontend/communect/src/components/group/GroupTree.jsx
+++ b/web/frontend/communect/src/components/group/GroupTree.jsx
@@ -14,26 +14,24 @@ function GroupTree({
   onUpdateGroup,
   onEditGroup,
   onShowMembers,
-  onOpenTalk, // onOpenTalkをプロパティとして受け取る
+  onOpenTalk, 
 }) {
   const [showPlusMenu, setShowPlusMenu] = useState(false);
-  const [isTalkOpen, setIsTalkOpen] = useState(false); // トーク画面の状態を管理
+  const [isTalkOpen, setIsTalkOpen] = useState(false); 
 
-  // 選択されたグループかどうかを判定
   const isSelected = currentGroup && currentGroup.groupId === group.groupId;
 
   const handleEditClick = () => {
-    console.log("グループ編集ボタンが押されました");
-    onEditGroup(group); // 親コンポーネントに通知
+    onEditGroup(group);
   };
 
   const handleTalkToggle = () => {
     if (isTalkOpen) {
       setIsTalkOpen(false);
-      onOpenTalk(null); // トーク画面を閉じる
+      onOpenTalk(null);
     } else {
       setIsTalkOpen(true);
-      onOpenTalk(group); // トーク画面を開く
+      onOpenTalk(group);
     }
   };
 
@@ -79,9 +77,9 @@ function GroupTree({
               onClick={handleTalkToggle} // 状態切り替えロジック
             >
               {isTalkOpen ? (
-                <i className="bi bi-arrow-left-circle"></i> // 戻るアイコン
+                <i className="bi bi-arrow-left-circle"></i> // 戻る
               ) : (
-                <i className="bi bi-chat-dots"></i> // トークアイコン
+                <i className="bi bi-chat-dots"></i> // トーク
               )}
             </button>
           </>
@@ -114,7 +112,7 @@ function GroupTree({
               onUpdateGroup={onUpdateGroup}
               onEditGroup={onEditGroup}
               onShowMembers={onShowMembers}
-              onOpenTalk={onOpenTalk} // 子にも渡す
+              onOpenTalk={onOpenTalk}
             />
           ))}
         </ul>
@@ -134,7 +132,7 @@ GroupTree.propTypes = {
   onUpdateGroup: PropTypes.func.isRequired,
   onEditGroup: PropTypes.func.isRequired,
   onShowMembers: PropTypes.func.isRequired,
-  onOpenTalk: PropTypes.func.isRequired, // 新しいプロパティ
+  onOpenTalk: PropTypes.func.isRequired,
 };
 
 export default GroupTree;

--- a/web/frontend/communect/src/components/group/UserSearch.jsx
+++ b/web/frontend/communect/src/components/group/UserSearch.jsx
@@ -8,38 +8,69 @@ function UserSearch({ onAddUsers, singleSelect = false }) {
   const [searchKeyword, setSearchKeyword] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [selectedUsers, setSelectedUsers] = useState([]);
+  const [currentUser, setCurrentUser] = useState(null);
+  const [isUserLoaded, setIsUserLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchCurrentUser = async () => {
+      try {
+        const response = await axios.get(import.meta.env.VITE_API_URL + "/user/login", {
+          withCredentials: true,
+          credentials: "include",
+        });
+        console.log("Current User:", response.data); // ログインユーザー情報を確認
+        setCurrentUser(response.data);
+      } catch (error) {
+        console.error("Error fetching current user:", error);
+      } finally {
+        setIsUserLoaded(true);
+      }
+    };
+    fetchCurrentUser();
+  }, []);
 
   const fetchUsers = async (keyword) => {
-    if (!keyword) {
+    if (!keyword || !currentUser) {
       setSearchResults([]);
       return;
     }
     try {
-      const response = await axios.get(import.meta.env.VITE_API_URL + `/user`, {
+      const response = await axios.get(import.meta.env.VITE_API_URL + "/user", {
         params: { keyword },
         withCredentials: true,
       });
-      const users = response.data.users;
-      if (Array.isArray(users)) {
-        setSearchResults(users);
-      } else {
-        setSearchResults([]);
-        console.error("Unexpected API response:", response.data);
+  
+      let users = response.data.users || [];
+  
+      // ログイン中のユーザーを除外（正しい userId を取得）
+      if (currentUser?.user?.userId) {
+        users = users.filter(user => user.userId !== currentUser.user.userId);
       }
+  
+      setSearchResults(users);
     } catch (error) {
       console.error("Error fetching users:", error);
       setSearchResults([]);
     }
   };
+  
 
   const debouncedFetchUsers = debounce(fetchUsers, 300);
 
   useEffect(() => {
-    debouncedFetchUsers(searchKeyword);
+    if (isUserLoaded && searchKeyword) {
+      debouncedFetchUsers(searchKeyword);
+    }
     return () => debouncedFetchUsers.cancel();
-  }, [searchKeyword]);
+  }, [searchKeyword, isUserLoaded]);
 
   const handleUserSelect = (user) => {
+    // 自分自身の選択を防止
+    if (user.userId === currentUser?.userId) {
+      console.warn("Cannot select current user");
+      return;
+    }
+
     if (singleSelect) {
       setSelectedUsers([user]);
       onAddUsers([user]);
@@ -48,6 +79,7 @@ function UserSearch({ onAddUsers, singleSelect = false }) {
       const updatedUsers = isSelected
         ? selectedUsers.filter((u) => u.userId !== user.userId)
         : [...selectedUsers, user];
+
       setSelectedUsers(updatedUsers);
       onAddUsers(updatedUsers);
     }
@@ -64,28 +96,16 @@ function UserSearch({ onAddUsers, singleSelect = false }) {
       />
       <Row className="search-results">
         {searchResults.map((user) => (
-          <Col
-            key={user.userId}
-            xs={12}
-            sm={6}
-            md={4}
-            className="mb-3"
-          >
+          <Col key={user.userId} xs={12} sm={6} md={4} className="mb-3">
             <Card
               className={`user-card ${
-                selectedUsers.some((u) => u.userId === user.userId)
-                  ? "selected"
-                  : ""
+                selectedUsers.some((u) => u.userId === user.userId) ? "selected" : ""
               }`}
               onClick={() => handleUserSelect(user)}
             >
               <Card.Body className="p-0">
-                <Card.Title className="user-name">
-                  {user.userName}
-                </Card.Title>
-                <Card.Text className="user-nickname">
-                  {user.nickName}
-                </Card.Text>
+                <Card.Title className="user-name">{user.userName}</Card.Title>
+                <Card.Text className="user-nickname">{user.nickName}</Card.Text>
               </Card.Body>
             </Card>
           </Col>

--- a/web/frontend/communect/src/components/group/UserSearch.jsx
+++ b/web/frontend/communect/src/components/group/UserSearch.jsx
@@ -18,7 +18,6 @@ function UserSearch({ onAddUsers, singleSelect = false }) {
           withCredentials: true,
           credentials: "include",
         });
-        console.log("Current User:", response.data); // ログインユーザー情報を確認
         setCurrentUser(response.data);
       } catch (error) {
         console.error("Error fetching current user:", error);
@@ -42,7 +41,6 @@ function UserSearch({ onAddUsers, singleSelect = false }) {
   
       let users = response.data.users || [];
   
-      // ログイン中のユーザーを除外（正しい userId を取得）
       if (currentUser?.user?.userId) {
         users = users.filter(user => user.userId !== currentUser.user.userId);
       }
@@ -65,11 +63,6 @@ function UserSearch({ onAddUsers, singleSelect = false }) {
   }, [searchKeyword, isUserLoaded]);
 
   const handleUserSelect = (user) => {
-    // 自分自身の選択を防止
-    if (user.userId === currentUser?.userId) {
-      console.warn("Cannot select current user");
-      return;
-    }
 
     if (singleSelect) {
       setSelectedUsers([user]);

--- a/web/frontend/communect/src/components/group/feature/AddUserModal.jsx
+++ b/web/frontend/communect/src/components/group/feature/AddUserModal.jsx
@@ -1,16 +1,26 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import axios from "axios";
 import { Modal, Button, Alert, Spinner } from "react-bootstrap";
 import UserSearch from "../../group/UserSearch";
 
-function AddUserModal({ groupId, show, onClose, onAddUser }) {
+function AddUserModal({ groupId, show, onClose, onAddUser, existingMembers }) {
   const [selectedUser, setSelectedUser] = useState(null);
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState(null);
+  const [excludedUserIds, setExcludedUserIds] = useState([]);
+
+  useEffect(() => {
+    setExcludedUserIds(existingMembers.map((member) => member.userId));
+  }, [existingMembers]);
 
   const handleAddUser = async () => {
     if (!selectedUser) return;
+
+    if (excludedUserIds.includes(selectedUser.userId)) {
+      setError("このユーザーはすでにグループメンバーです。");
+      return;
+    }
 
     setAdding(true);
     setError(null);
@@ -49,6 +59,7 @@ function AddUserModal({ groupId, show, onClose, onAddUser }) {
           <UserSearch
             onAddUsers={(users) => setSelectedUser(users[0] || null)}
             singleSelect
+            excludeUsers={excludedUserIds} // 既存メンバーを除外
           />
           {selectedUser && (
             <div className="mt-3">
@@ -91,6 +102,7 @@ AddUserModal.propTypes = {
   show: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onAddUser: PropTypes.func.isRequired,
+  existingMembers: PropTypes.array.isRequired,
 };
 
 export default AddUserModal;

--- a/web/frontend/communect/src/components/group/feature/DeleteButton.jsx
+++ b/web/frontend/communect/src/components/group/feature/DeleteButton.jsx
@@ -1,38 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 
 function DeleteButton({ groupId, onDelete }) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
   const handleDelete = async () => {
+    if (isDeleting) return; // 二重実行防止
     if (!window.confirm("このグループを削除しますか？")) return;
 
+    setIsDeleting(true); // 削除処理開始
     try {
       const response = await fetch(
         `${import.meta.env.VITE_API_URL}/group/${groupId}`,
         {
           method: "DELETE",
-          credentials: "include", // クッキー認証を有効にする
+          credentials: "include",
           headers: {
-            "Content-Type": "application/json", // 必要に応じて追加
+            "Content-Type": "application/json",
           },
         }
       );
+
       if (!response.ok) {
-        throw new Error("Failed to delete group");
+        const errorText = await response.text(); // エラーメッセージを取得
+        throw new Error(`Failed to delete group: ${errorText}`);
       }
-      onDelete(groupId); // UI更新を親コンポーネントに通知
+
+      // 削除が成功したら、親コンポーネントに通知
+      onDelete(groupId);
     } catch (err) {
       console.error("Error deleting group:", err);
-      alert("グループの削除に失敗しました。もう一度試してください。");
+      alert(`グループの削除に失敗しました: ${err.message}`);
+    } finally {
+      setIsDeleting(false); // 処理完了後に解除
     }
   };
 
   return (
     <i
-      className="bi bi-trash-fill text-danger ms-2"
+      className={`bi bi-trash-fill text-danger ms-2 ${isDeleting ? "disabled" : ""}`}
       role="button"
       title="グループを削除"
       onClick={handleDelete}
-      style={{ cursor: "pointer" }}
+      style={{ cursor: isDeleting ? "not-allowed" : "pointer" }}
     ></i>
   );
 }

--- a/web/frontend/communect/src/components/group/feature/EditGroupMemberModal.jsx
+++ b/web/frontend/communect/src/components/group/feature/EditGroupMemberModal.jsx
@@ -62,7 +62,9 @@ function EditGroupMemberModal({ groupId, member, currentUserId, show, onClose, o
     }
 
     try {
-      const response = await axios.put(`${import.meta.env.VITE_API_URL}/group/${groupId}/user`, updatedMember);
+      const response = await axios.put(`${import.meta.env.VITE_API_URL}/group/${groupId}/user`, updatedMember,
+        { withCredentials: true , credentials: "include"}
+      );
       onSave(response.data.user);
       onClose();
     } catch (err) {

--- a/web/frontend/communect/src/components/group/feature/EditGroupMemberModal.jsx
+++ b/web/frontend/communect/src/components/group/feature/EditGroupMemberModal.jsx
@@ -10,7 +10,7 @@ const ROLE_DISPLAY_MAP = {
   NONE: "なし",
 };
 
-function EditGroupMemberModal({ groupId, member, show, onClose, onSave }) {
+function EditGroupMemberModal({ member, show, onClose, onSave }) {
   const [formData, setFormData] = useState({
     nickName: member.nickName || "",
     role: member.role || "",
@@ -28,9 +28,8 @@ function EditGroupMemberModal({ groupId, member, show, onClose, onSave }) {
   };
 
   const validateForm = () => {
-    // 必須フィールドの検証
     if (!formData.nickName || !formData.role) {
-      setError("All fields must be filled out.");
+      setError("名前と連絡権限は必須です。");
       return false;
     }
     setError(null);
@@ -42,7 +41,7 @@ function EditGroupMemberModal({ groupId, member, show, onClose, onSave }) {
 
     const updatedMember = { ...member, ...formData };
     onSave(updatedMember); // 親コンポーネントに更新されたメンバー情報を渡す
-    onClose(); // モーダルを閉じる
+    onClose();
   };
 
   return (
@@ -81,14 +80,14 @@ function EditGroupMemberModal({ groupId, member, show, onClose, onSave }) {
           <Form.Group className="mb-3">
             <Form.Check
               type="checkbox"
-              label="Admin"
+              label="管理者権限"
               name="isAdmin"
               checked={formData.isAdmin}
               onChange={handleChange}
             />
             <Form.Check
               type="checkbox"
-              label="Can create sub-group"
+              label="下位グループ作成権限"
               name="isSubGroupCreate"
               checked={formData.isSubGroupCreate}
               onChange={handleChange}

--- a/web/frontend/communect/src/components/group/feature/EditGroupMemberModal.jsx
+++ b/web/frontend/communect/src/components/group/feature/EditGroupMemberModal.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button, Form, Alert } from "react-bootstrap";
+import axios from "axios"; // APIリクエスト用
 
 const ROLE_DISPLAY_MAP = {
   HIGH: "高",
@@ -10,7 +11,7 @@ const ROLE_DISPLAY_MAP = {
   NONE: "なし",
 };
 
-function EditGroupMemberModal({ member, show, onClose, onSave }) {
+function EditGroupMemberModal({ groupId, member, currentUserId, show, onClose, onSave }) {
   const [formData, setFormData] = useState({
     nickName: member.nickName || "",
     role: member.role || "",
@@ -18,6 +19,19 @@ function EditGroupMemberModal({ member, show, onClose, onSave }) {
     isSubGroupCreate: member.isSubGroupCreate || false,
   });
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false); // ローディング状態
+
+  useEffect(() => {
+    // 自分の情報を編集する場合、ニックネームのみ変更可能に制限
+    if (member.userId === currentUserId) {
+      setFormData((prev) => ({
+        ...prev,
+        role: null, // 自分自身の編集ではroleは変更できない
+        isAdmin: null, // 自分自身の編集ではisAdminは変更できない
+        isSubGroupCreate: null, // 自分自身の編集ではisSubGroupCreateは変更できない
+      }));
+    }
+  }, [member, currentUserId]);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -28,20 +42,52 @@ function EditGroupMemberModal({ member, show, onClose, onSave }) {
   };
 
   const validateForm = () => {
-    if (!formData.nickName || !formData.role) {
-      setError("名前と連絡権限は必須です。");
+    if (!formData.nickName) {
+      setError("ニックネームは必須です。");
       return false;
     }
+
+    // 管理者権限を持たない場合はエラー
+    if (member.userId !== currentUserId && !member.isAdmin) {
+      setError("管理者権限がないため、このメンバーを編集できません。");
+      return false;
+    }
+
     setError(null);
     return true;
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!validateForm()) return;
 
-    const updatedMember = { ...member, ...formData };
-    onSave(updatedMember); // 親コンポーネントに更新されたメンバー情報を渡す
-    onClose();
+    setLoading(true); // リクエスト開始
+
+    // 自分自身を編集する場合、ニックネームだけ変更できるように設定
+    const updatedMember = { ...formData, groupUserId: member.groupUserId };
+
+    // 自分の情報を編集する場合、役割や管理者権限は含めない
+    if (member.userId === currentUserId) {
+      delete updatedMember.role;
+      delete updatedMember.isAdmin;
+      delete updatedMember.isSubGroupCreate;
+    }
+
+    try {
+      // APIリクエスト
+      const response = await axios.put(
+        `/group/${groupId}/user`,
+        updatedMember
+      );
+      
+      // 成功時の処理
+      onSave(response.data.user); // 親コンポーネントにデータを渡す
+      onClose();
+    } catch (err) {
+      // エラーハンドリング
+      setError("メンバーの更新に失敗しました。再度お試しください。");
+    } finally {
+      setLoading(false); // ローディング解除
+    }
   };
 
   return (
@@ -59,48 +105,57 @@ function EditGroupMemberModal({ member, show, onClose, onSave }) {
               name="nickName"
               value={formData.nickName}
               onChange={handleChange}
+              disabled={member.userId === currentUserId} // 自分のニックネームは編集不可
             />
           </Form.Group>
-          <Form.Group className="mb-3">
-            <Form.Label>連絡権限</Form.Label>
-            <Form.Control
-              as="select"
-              name="role"
-              value={formData.role}
-              onChange={handleChange}
-            >
-              <option value="">選択してください</option>
-              {Object.keys(ROLE_DISPLAY_MAP).map((role) => (
-                <option key={role} value={role}>
-                  {ROLE_DISPLAY_MAP[role]}
-                </option>
-              ))}
-            </Form.Control>
-          </Form.Group>
-          <Form.Group className="mb-3">
-            <Form.Check
-              type="checkbox"
-              label="管理者権限"
-              name="isAdmin"
-              checked={formData.isAdmin}
-              onChange={handleChange}
-            />
-            <Form.Check
-              type="checkbox"
-              label="下位グループ作成権限"
-              name="isSubGroupCreate"
-              checked={formData.isSubGroupCreate}
-              onChange={handleChange}
-            />
-          </Form.Group>
+          {member.userId !== currentUserId && (
+            <>
+              <Form.Group className="mb-3">
+                <Form.Label>連絡権限</Form.Label>
+                <Form.Control
+                  as="select"
+                  name="role"
+                  value={formData.role}
+                  onChange={handleChange}
+                >
+                  <option value="">選択してください</option>
+                  {Object.keys(ROLE_DISPLAY_MAP).map((role) => (
+                    <option key={role} value={role}>
+                      {ROLE_DISPLAY_MAP[role]}
+                    </option>
+                  ))}
+                </Form.Control>
+              </Form.Group>
+              <Form.Group className="mb-3">
+                <Form.Check
+                  type="checkbox"
+                  label="Admin"
+                  name="isAdmin"
+                  checked={formData.isAdmin}
+                  onChange={handleChange}
+                />
+                <Form.Check
+                  type="checkbox"
+                  label="Can create sub-group"
+                  name="isSubGroupCreate"
+                  checked={formData.isSubGroupCreate}
+                  onChange={handleChange}
+                />
+              </Form.Group>
+            </>
+          )}
         </Form>
       </Modal.Body>
       <Modal.Footer>
         <Button variant="secondary" onClick={onClose}>
           やめる
         </Button>
-        <Button variant="primary" onClick={handleSubmit}>
-          保存
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          disabled={loading} // ローディング中はボタン無効化
+        >
+          {loading ? "保存中..." : "保存"}
         </Button>
       </Modal.Footer>
     </Modal>
@@ -110,6 +165,7 @@ function EditGroupMemberModal({ member, show, onClose, onSave }) {
 EditGroupMemberModal.propTypes = {
   groupId: PropTypes.string.isRequired,
   member: PropTypes.object.isRequired,
+  currentUserId: PropTypes.string.isRequired, // 現在ログインしているユーザーID
   show: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,

--- a/web/frontend/communect/src/components/group/feature/EditGroupModal.jsx
+++ b/web/frontend/communect/src/components/group/feature/EditGroupModal.jsx
@@ -5,7 +5,7 @@ import axios from "axios";
 
 function EditGroupModal({ group, onClose, onUpdateGroup }) {
   const [name, setName] = useState(group.groupName || "");
-  const [isParentGroup, setIsParentGroup] = useState(!group.aboveGroupId); // 最上位親グループか判定
+  const [isParentGroup, setIsParentGroup] = useState(!group.aboveGroupId);
 
   useEffect(() => {
     if (!isParentGroup) {
@@ -27,7 +27,7 @@ function EditGroupModal({ group, onClose, onUpdateGroup }) {
   
       if (response.status === 200) {
         onUpdateGroup(group.groupId, payload.name); // 親に変更を通知
-        onClose(); // モーダルを閉じる
+        onClose();
       }
     } catch (error) {
       console.error("グループ更新エラー:", error);

--- a/web/frontend/communect/src/components/group/feature/EditGroupModal.jsx
+++ b/web/frontend/communect/src/components/group/feature/EditGroupModal.jsx
@@ -5,58 +5,28 @@ import axios from "axios";
 
 function EditGroupModal({ group, onClose, onUpdateGroup }) {
   const [name, setName] = useState(group.groupName || "");
-  const [above, setAbove] = useState(group.aboveGroupId || "");
   const [isParentGroup, setIsParentGroup] = useState(!group.aboveGroupId); // 最上位親グループか判定
-  const [groupOptions, setGroupOptions] = useState([]); // 上位グループ候補リスト
 
-  // 上位グループ候補の取得
   useEffect(() => {
     if (!isParentGroup) {
       fetchGroupOptions();
     }
   }, [isParentGroup]);
 
-  // グループリストの取得
-  /* その最上位親グループの中のグループを取得する処理をここで実装するのは現実的ではないので一旦保留。*/
-  const fetchGroupOptions = async () => {
-    try {
-      const response = await axios.get(import.meta.env.VITE_API_URL + "/group" ,
-        {
-          withCredentials: true,
-        }
-      );
-  
-      const groups = response.data.groups;
-  
-      if (Array.isArray(groups)) {
-        // 選択されたグループの親（aboveId）に一致するグループのみを取得
-        const filteredGroups = groups.filter(
-          (g) => g.groupId === group.aboveGroupId
-        );
-        setGroupOptions(filteredGroups);
-      } else {
-        throw new Error("グループデータが配列ではありません");
-      }
-    } catch (error) {
-      console.error("グループリスト取得エラー:", error);
-      alert("上位グループリストの取得に失敗しました");
-    }
-  };
-  
-
   const handleSave = async () => {
     try {
       const payload = {
         name: name.trim() || null,
-        above: isParentGroup ? null : above.trim() || null,
       };
-
-      const response = await axios.put(import.meta.env.VITE_API_URL + `/group/${group.groupId}`, payload ,{
-        withCredentials: true,
-      });
+  
+      const response = await axios.put(
+        `${import.meta.env.VITE_API_URL}/group/${group.groupId}`,
+        payload,
+        { withCredentials: true }
+      );
+  
       if (response.status === 200) {
-        alert("グループが更新されました。再読み込みを行ってください。");
-        onUpdateGroup(group.groupId, payload); // 親に通知
+        onUpdateGroup(group.groupId, payload.name); // 親に変更を通知
         onClose(); // モーダルを閉じる
       }
     } catch (error) {
@@ -81,25 +51,6 @@ function EditGroupModal({ group, onClose, onUpdateGroup }) {
               placeholder="グループ名を入力"
             />
           </Form.Group>
-
-          {/* 上位グループ選択 */}
-          {!isParentGroup && (
-            <Form.Group controlId="aboveGroupId" className="mt-3">
-              <Form.Label>上位グループ</Form.Label>
-              <Form.Control
-                as="select"
-                value={above}
-                onChange={(e) => setAbove(e.target.value)}
-              >
-                <option value="">-- 上位グループを選択 --</option>
-                {groupOptions.map((g) => (
-                  <option key={g.groupId} value={g.groupId}>
-                    {g.groupName}
-                  </option>
-                ))}
-              </Form.Control>
-            </Form.Group>
-          )}
         </Form>
       </Modal.Body>
       <Modal.Footer>

--- a/web/frontend/communect/src/components/message/MessagesArea.jsx
+++ b/web/frontend/communect/src/components/message/MessagesArea.jsx
@@ -21,10 +21,13 @@ const MessagesArea = ({
   useEffect(() => {
     const fetchCurrentUser = async () => {
       try {
-        const response = await axios.get(import.meta.env.VITE_API_URL + "/user/login", {
-          withCredentials: true,
-          credentials: "include",
-        });
+        const response = await axios.get(
+          import.meta.env.VITE_API_URL + "/user/login",
+          {
+            withCredentials: true,
+            credentials: "include",
+          }
+        );
         setCurrentUser(response.data.user);
       } catch (error) {
         console.error("ログインユーザー情報の取得に失敗しました:", error);
@@ -41,10 +44,11 @@ const MessagesArea = ({
   };
 
   useEffect(() => {
-    // スクロールが一番下にある場合、送信後に最下部にスクロール
+    // メッセージが更新されたとき、スクロールを最下部に調整
     const container = messagesContainerRef.current;
-    const isAtBottom = container.scrollHeight === container.scrollTop + container.clientHeight;
-    
+    const isAtBottom =
+      container.scrollHeight === container.scrollTop + container.clientHeight;
+
     if (isAtBottom) {
       scrollToBottom();
     }
@@ -75,11 +79,10 @@ const MessagesArea = ({
     <Col xs={9} className={`${styles["messages-container"]} p-0`}>
       <div
         className={`${styles.messages} flex-grow-1 overflow-auto`}
-        ref={messagesContainerRef} // メッセージコンテナにrefを追加
+        ref={messagesContainerRef}
       >
         {messages.length > 0 ? (
-          // メッセージを降順に表示（最新のメッセージが下に）
-          [...messages].reverse().map((message) => (
+          messages.map((message) => (
             <div
               key={message.messageId}
               className={`${styles.message} ${
@@ -134,10 +137,11 @@ const MessagesArea = ({
         ) : (
           <p className={styles["no-messages"]}>まだメッセージはありません。</p>
         )}
-        {/* 最後のメッセージの下にスクロールを誘導 */}
         <div ref={messagesEndRef}></div>
       </div>
-      {selectedTalk && <MessageSender talkId={selectedTalk} onMessageSent={onSendMessage} />}
+      {selectedTalk && (
+        <MessageSender talkId={selectedTalk} onMessageSent={onSendMessage} />
+      )}
     </Col>
   );
 };

--- a/web/frontend/communect/src/components/message/MessagesArea.jsx
+++ b/web/frontend/communect/src/components/message/MessagesArea.jsx
@@ -82,6 +82,7 @@ const MessagesArea = ({
         ref={messagesContainerRef}
       >
         {messages.length > 0 ? (
+          // メッセージをそのまま表示
           messages.map((message) => (
             <div
               key={message.messageId}
@@ -140,7 +141,14 @@ const MessagesArea = ({
         <div ref={messagesEndRef}></div>
       </div>
       {selectedTalk && (
-        <MessageSender talkId={selectedTalk} onMessageSent={onSendMessage} />
+        <MessageSender
+          talkId={selectedTalk}
+          onMessageSent={(newMessage) => {
+            // 新しいメッセージが送信された後、逆順で追加
+            onSendMessage(newMessage); // メッセージ送信後に状態更新
+            scrollToBottom(); // 最下部にスクロール
+          }}
+        />
       )}
     </Col>
   );

--- a/web/frontend/communect/src/css/accountRegister.css
+++ b/web/frontend/communect/src/css/accountRegister.css
@@ -1,7 +1,3 @@
-h2 {
-  color: black;
-}
-
 .card {
   z-index: 1;
   background-color: rgba(255, 255, 255, 0.95);
@@ -14,11 +10,11 @@ h2 {
   color: black;
 }
 
-a:hover {
-  color: #00ffff;
+h2 {
+  color: black;
 }
 
-.font {
-  font-family: "Mochiy Pop One", sans-serif;
-  font-size: 20px;
+button {
+  font-size: 16px;
+  padding: 10px;
 }

--- a/web/frontend/communect/src/css/main.css
+++ b/web/frontend/communect/src/css/main.css
@@ -1,17 +1,17 @@
 header {
     position: fixed;
-    height: 70px; /* ヘッダーの高さを固定 */
+    height: 70px;
     top: 0;
     left: 0;
   }
   
   body {
-    overflow-y: scroll; /* 常にスクロールバーを表示 */
+    overflow-y: scroll;
   }
   
   main {
     margin-top: 70px;
-    height: calc(100vh - 70px); /* 残り画面を埋める */
+    height: calc(100vh - 70px); 
     overflow: hidden;
     display: flex;
   }
@@ -22,18 +22,19 @@ header {
   
   .maincontent {
     background-color: rgb(235, 235, 235);
+    padding-left: 4.5rem;
   }
   
   .flex-grow-1 {
     display: flex;
-    flex-direction: column; /* 子要素を縦並びにする */
+    flex-direction: column; 
     width: auto;
-    overflow: hidden; /* 子要素のオーバーフローを防止 */
+    overflow: hidden;
   }
   
   .card {
     display: flex;
-    flex-direction: column; /* GroupTalk用の縦並び */
+    flex-direction: column; 
     --bs-card-border-width: 0;
   }
   
@@ -41,11 +42,11 @@ header {
     border: none;
     background-color: transparent;
     font-size: 20px;
-    margin-left: auto; /* ボタンを右端に配置 */
+    margin-left: auto;
   }
   
   .rotate-icon {
-    display: inline-block; /* 回転を適用可能にする */
+    display: inline-block; 
     transition: transform 0.2s ease;
   }
   
@@ -53,7 +54,6 @@ header {
     transform: rotate(90deg); /* 折りたたみ表示 */
   }
   
-  /* サイドバー開閉アイコン */
   .sidebar-toggle-icon {
     background-color: #007bff;
     color: white;

--- a/web/frontend/communect/src/css/module/groupTalk.module.css
+++ b/web/frontend/communect/src/css/module/groupTalk.module.css
@@ -1,8 +1,8 @@
 .talk-room {
-  margin: 0; /* 余分なマージンを削除 */
-  padding: 0; /* 余分なパディングを削除 */
-  height: 100%; /* 全体の高さを明確に定義 */
-  overflow: hidden; /* 必要な場合にのみスクロール */
+  margin: 0;
+  padding: 0; 
+  height: 100%; 
+  overflow: hidden; 
   height: calc(100vh - 70px);
 }
 

--- a/web/frontend/communect/src/css/module/postFormModal.module.css
+++ b/web/frontend/communect/src/css/module/postFormModal.module.css
@@ -1,0 +1,62 @@
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1050;
+}
+
+.modalContent {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  width: 400px;
+  max-width: 90%;
+  position: relative;
+}
+
+.btnClose {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.formGroup {
+  margin-bottom: 15px;
+}
+
+.btnPrimary {
+  width: 100%;
+  padding: 10px;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.choiceInput {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.btnDelete {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.btnDelete:hover {
+  background-color: #c82333;
+}

--- a/web/frontend/communect/src/css/top.css
+++ b/web/frontend/communect/src/css/top.css
@@ -42,6 +42,7 @@ main {
   font-family: "Mochiy Pop One", sans-serif;
   font-weight: 400;
   font-style: normal;
+  text-wrap: nowrap;
 }
 
 /* 要素がふわっと現れるアニメーション */


### PR DESCRIPTION
##  Add Work Tasks

### Account
- [x] アカウント登録機能の確認
- [x] アカウント登録画面のレイアウトの修正
- [x] Login画面からアカウント登録画面への遷移及びログイン画面のレイアウト調整

### Group
- [x] グループ削除機能を正しく動作するように修正
- [x] グループ編集機能でのグループ名更新時、グループ名がパンくずリスト/連絡画面/グループツリーでの即時反映
- [x] グループメンバー機能でメンバーの削除・編集・追加後の即時更新及び反映
- [x] グループ作成・メンバー追加時のユーザ検索で自分自身を反映しない
- [x] グループメンバー編集API接続処理の追加

### Contact
- [x] 多肢連絡編集時に選択肢が反映されなくなる不具合の修正
- [x] 多肢連絡新規投稿時に入力した順番の選択肢を反映するように修正
- [x] 通知で確認を押した場合に、連絡画面の確認ボタンを押すとメッセージが返されるようにする。(※後に確認ボタン及び選択肢を押せないようにする)
- [x] 周知・確認連絡の編集を行った際に正常に編集され、反映されるように修正を行う

### Talk
- [x] DM機能のSSE追加
- [x] GroupTalkのSSE接続部分のクエリの削除
- [x] メッセージを時系列順に表示させる
